### PR TITLE
Agregamos flags de compilación estrictos.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+heritage

--- a/Ejercicio1.cpp
+++ b/Ejercicio1.cpp
@@ -10,7 +10,7 @@ Clase hija:
 #include<iostream>
 #include<string>
 
-using std::cin;
+using std::cin; // declarativa -using- inutilizada.
 using std::cout;
 using std::string;
 
@@ -214,7 +214,8 @@ void Empleados::EmpleadoInfo()
 }
 
 
-int main(void){
+int main(void)
+{
     Estudiantes xEstudiante;
     Empleados xEmpleado;
     cout<<"****HERENCIA MULTIPLE EN C++****\n";

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,5 @@
+-std=c++20
+-Wall
+-Wextra
+-Wpedantic
+-Werror

--- a/makefile
+++ b/makefile
@@ -1,2 +1,3 @@
-heritage.exe: Ejercicio1.cpp
-	g++ Ejercicio1.cpp -o heritage.exe
+heritage: Ejercicio1.cpp
+	g++ Ejercicio1.cpp \
+		-Wall -Wextra -Wpedantic -Werror -o heritage


### PR DESCRIPTION
Los flags se agregaron en makefile. El programa por ahora deberá ser adecuado al entorno Windows agregando la extensión .exe al ejecutable.

También se crea compile_flags.txt que es otro método por el cual los servidores de lenguaje entienden cómo deben de analizar tu código.